### PR TITLE
Allow to create TinyMCE instances w/out mode=exact configuration param

### DIFF
--- a/tinymce/widgets.py
+++ b/tinymce/widgets.py
@@ -62,8 +62,10 @@ class TinyMCE(forms.Textarea):
         if tinymce.settings.USE_FILEBROWSER:
             mce_config['file_browser_callback'] = "djangoFileBrowser"
         mce_config.update(self.mce_attrs)
-        mce_config['mode'] = 'exact'
-        mce_config['elements'] = final_attrs['id']
+        if not 'mode' in mce_config:
+            mce_config['mode'] = 'exact'
+        if mce_config['mode'] == 'exact':
+            mce_config['elements'] = final_attrs['id']
         mce_config['strict_loading_mode'] = 1
         mce_json = simplejson.dumps(mce_config)
 


### PR DESCRIPTION
Allow to create TinyMCE instances w/out mode=exact configuration parameter (useful e.g. if one wants to activate editor instance manually)
