### PR TITLE
Bug fix: set JS_ROOT when staticfiles isn't on INSTALLED_APPS.

### DIFF
--- a/tinymce/settings.py
+++ b/tinymce/settings.py
@@ -16,5 +16,6 @@ if 'staticfiles' in settings.INSTALLED_APPS or 'django.contrib.staticfiles' in s
     JS_ROOT = getattr(settings, 'TINYMCE_JS_ROOT',os.path.join(settings.STATIC_ROOT, 'tiny_mce'))
 else:
     JS_URL = getattr(settings, 'TINYMCE_JS_URL','%sjs/tiny_mce/tiny_mce.js' % settings.MEDIA_URL)
+    JS_ROOT = getattr(settings, 'TINYMCE_JS_ROOT', os.path.join(settings.MEDIA_ROOT, 'js/tiny_mce'))
 
 JS_BASE_URL = JS_URL[:JS_URL.rfind('/')]


### PR DESCRIPTION
Looks like that line got missing by accident.
