### PR TITLE
Add South compatibility

### DIFF
--- a/tinymce/models.py
+++ b/tinymce/models.py
@@ -4,6 +4,11 @@
 from django.db import models
 from django.contrib.admin import widgets as admin_widgets
 from tinymce import widgets as tinymce_widgets
+try:
+    from south.modelsinspector import add_introspection_rules
+    add_introspection_rules([], ['^tinymce\.models\.HTMLField'])
+except ImportError:
+    pass
 
 class HTMLField(models.TextField):
     """


### PR DESCRIPTION
This just applies the patch from Google Code [issue 80](http://code.google.com/p/django-tinymce/issues/detail?id=80), which lets South generate migrations for models that use `HTMLField`.
