### PR TITLE
Allow overriding the JS_URL and JS_ROOT settings - important when staticfiles are hosted on CDN

### DIFF
--- a/tinymce/settings.py
+++ b/tinymce/settings.py
@@ -14,7 +14,7 @@ USE_FILEBROWSER = getattr(settings, 'TINYMCE_FILEBROWSER',
 JS_URL = getattr(settings, 'TINYMCE_JS_URL', None)
 JS_ROOT = getattr(settings, 'TINYMCE_JS_ROOT', None)
 
-# Allways allow overriding of the default settings
+# Always allow overriding of the default settings
 if 'staticfiles' in settings.INSTALLED_APPS or 'django.contrib.staticfiles' in settings.INSTALLED_APPS:
     if not JS_URL:
         JS_URL = os.path.join(getattr(settings, 'STATIC_URL', ''), 'tiny_mce/tiny_mce.js')


### PR DESCRIPTION
When Django's staticfiles are hosted externally, for example through a CDN, the same-origin policy prevents TinyMCE from functioning properly. Therefore, I made a small patch to allow overriding of `JS_URL` and `JS_ROOT` from Django's `settings`.

When this setting is not specified, the original defaults are used. When they _are_ specified, the defaults are ignored.
