### PR TITLE
Django Admin mixins for dynamic TinyMCE link and image lists

### DIFF
--- a/tinymce/admin.py
+++ b/tinymce/admin.py
@@ -15,7 +15,7 @@ from tinymce.views import render_to_image_list, render_to_link_list
 
 
 class TinyMCEImageListMixin(object):
-    """ 
+    """
     Example usage::
         related_image_field = 'image'
         related_image_size = '200x300'

--- a/tinymce/utils.py
+++ b/tinymce/utils.py
@@ -8,7 +8,7 @@ class ExtendibleModelAdminMixin(object):
     def _getobj(self, request, object_id):
             opts = self.model._meta
             app_label = opts.app_label
-    
+
             try:
                 obj = self.queryset(request).get(pk=unquote(object_id))
             except self.model.DoesNotExist:
@@ -16,18 +16,18 @@ class ExtendibleModelAdminMixin(object):
                 # permissions yet. We don't want an unauthenticated user to be able
                 # to determine whether a given object exists.
                 obj = None
-    
+
             if obj is None:
                 raise Http404(_('%(name)s object with primary key %(key)r does not exist.') % {'name': force_unicode(opts.verbose_name), 'key': escape(object_id)})
 
             return obj
-    
+
     def _wrap(self, view):
         def wrapper(*args, **kwargs):
             return self.admin_site.admin_view(view)(*args, **kwargs)
         return update_wrapper(wrapper, view)
-    
+
     def _view_name(self, name):
         info = self.model._meta.app_label, self.model._meta.module_name, name
-        
+
         return '%s_%s_%s' % info


### PR DESCRIPTION
I produced Django Admin Mixin classes which allow for simple, easy and dynamic link and image lists within the editor. It also allows for easy and dynamic configuration of the fields for which TinyMCE should be used.

Example usage:

```
class BananaAdmin(TinyMCEAdminListMixin, TinyMCEImageListMixin):
    model = Banana

    tinymce_fields = ('description', )

    related_image_field = 'image'
    related_image_size = '200x300'

    def get_related_images(cls, request, obj):
        return obj.bananaimage_set.all()

    def get_image_list_url(self, request, field, obj=None):
        if obj:
            return reverse('admin:banana_image_list', \
                                         args=(obj.pk, ))
        else:
            return None
```

(Yes, I would like to make the `get_image_list_url` default to the `get_image_list_url`-function above - as it only has to be overridden in case you want to use images/links on inline admin objects using images/links from the parent object - but I have no time to do proper test it and don't want to bother you with untested stuff.)
