### PR TITLE
Remove unused 'from django import forms' statement in usage.rst FlatPage...

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -177,7 +177,6 @@ all ``django.contrib.flatpages`` objects:
 the flatpages ``content`` field with a predefined list of other flatpages in
 the link dialog you could use something like this::
 
-  from django import forms
   from django.core.urlresolvers import reverse
   from django.contrib.flatpages.admin import FlatPageAdmin
   from django.contrib.flatpages.models import FlatPage


### PR DESCRIPTION
Please review, and if you have any pointers (I'm new to GitHub and the contributing process) feel free to let me know.
