### PR TITLE
Fix template syntax error when using django 1.5

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -97,8 +97,9 @@ If you cannot or will not change the widget on a form you can also use the
 TinyMCE editors. On the template of the page, add the following lines to the
 ``HEAD`` element::
 
+  {% load url from future %}
   <script type="text/javascript" src="{{ MEDIA_URL }}js/tiny_mce/tiny_mce.js"></script>
-  <script type="text/javascript" src="{% url tinymce-js "NAME" %}"></script>
+  <script type="text/javascript" src="{% url "tinymce-js" "NAME" %}"></script>
 
 The ``NAME`` argument allows you to create multiple TinyMCE configurations. Now
 create a template containing the Javascript initialization code. It should be
@@ -122,7 +123,8 @@ variables are based on the current Django language. If the content language is
 different from the interface language use the ``tinymce-js-lang`` view which
 takes a language (``LANG_CODE``) argument::
 
-  <script type="text/javascript" src="{% url tinymce-js-lang "NAME","LANG_CODE" %}"></script>
+  {% load url from future %}
+  <script type="text/javascript" src="{% url "tinymce-js-lang" "NAME","LANG_CODE" %}"></script>
 
 
 External link and image lists

--- a/tinymce/templates/tinymce/tiny_mce_gzip.js
+++ b/tinymce/templates/tinymce/tiny_mce_gzip.js
@@ -1,4 +1,4 @@
-/**
+{% load url from future %}/**
  * Based on "TinyMCE Compressor PHP v2.0.4" from MoxieCode.
  *
  * http://tinymce.moxiecode.com/
@@ -12,7 +12,7 @@ var tinyMCE_GZ = {
 		plugins : '',
 		languages : '',
 		disk_cache : true,
-		page_name : '{% url tinymce-compressor %}',
+		page_name : '{% url "tinymce-compressor" %}',
 		debug : false,
 		suffix : ''
 	},


### PR DESCRIPTION
In django 1.5 the `{% url %}` tag no longer accepts a view name unless it's quoted correctly. This fixes the broken tag in django-tinymce and the two mentions in the docs.

While the `{% load url from future %}` is unnecessary in 1.5, it's required for backwards compatibility with django 1.4.

https://docs.djangoproject.com/en/1.5/internals/deprecation/#id2
