### PR TITLE
smart_unicode name changed to smart_text

### DIFF
--- a/tinymce/widgets.py
+++ b/tinymce/widgets.py
@@ -12,9 +12,12 @@ from django.contrib.admin import widgets as admin_widgets
 from django.core.urlresolvers import reverse
 from django.forms.widgets import flatatt
 try:
-    from django.utils.encoding import smart_unicode
+    from django.utils.encoding import smart_text as smart_unicode
 except ImportError:
-    from django.forms.util import smart_unicode
+    try:
+        from django.utils.encoding import smart_unicode
+    except ImportError:
+        from django.forms.util import smart_unicode
 from django.utils.html import escape
 from django.utils import simplejson
 from django.utils.datastructures import SortedDict


### PR DESCRIPTION
...xt (python3 support).

Try to import the last one and maintaing the old imports for backward compatibility.
I'm sure that there is a better/cleaner way of doing this
