### PR TITLE
Fixed import of url-related functions

### DIFF
--- a/tinymce/urls.py
+++ b/tinymce/urls.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2008 Joost Cassee
 # Licensed under the terms of the MIT License (see LICENSE.txt)
 
-from django.conf.urls.defaults import *
+from django.conf.urls import url, patterns
 
 urlpatterns = patterns('tinymce.views',
     url(r'^js/textareas/(?P<name>.+)/$', 'textareas_js', name='tinymce-js'),


### PR DESCRIPTION
Importing _defaults_ raises DeprecationWarning in Django 1.5
