### PR TITLE
Convert string to bytes before passing to compress_string

### DIFF
--- a/tinymce/compressor.py
+++ b/tinymce/compressor.py
@@ -121,7 +121,7 @@ def gzip_compressor(request):
 
     # Compress
     if compress:
-        content = compress_string(''.join(content))
+        content = compress_string(bytes(''.join(content), 'UTF-8'))
         response['Content-Encoding'] = 'gzip'
         response['Content-Length'] = str(len(content))
 


### PR DESCRIPTION
Using Django 1.6 and Python 3.3, django-tinymce 1.5.2 gives this error when trying to use `TINYMCE_COMPRESSOR = True`:

```
[04/Dec/2013 08:13:36] "GET /tinymce/compressor/ HTTP/1.1" 200 3157
Internal Server Error: /tinymce/compressor/
Traceback (most recent call last):
  File "/home/vkurup/.virtualenvs/rsvp/lib/python3.3/site-packages/django/core/handlers/base.py", line 114, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/home/vkurup/.virtualenvs/rsvp/lib/python3.3/site-packages/tinymce/views.py", line 112, in compressor
    return gzip_compressor(request)
  File "/home/vkurup/.virtualenvs/rsvp/lib/python3.3/site-packages/tinymce/compressor.py", line 124, in gzip_compressor
    content = compress_string(''.join(content))
  File "/home/vkurup/.virtualenvs/rsvp/lib/python3.3/site-packages/django/utils/text.py", line 272, in compress_string
    zfile.write(s)
  File "/usr/lib/python3.3/gzip.py", line 341, in write
    self.crc = zlib.crc32(data, self.crc) & 0xffffffff
TypeError: 'str' does not support the buffer interface
```

The attached PR fixes the issue for me.