### PR TITLE
Change inheritance order for admin widget

### DIFF
--- a/tinymce/widgets.py
+++ b/tinymce/widgets.py
@@ -139,7 +139,7 @@ setTimeout(function () {
     media = property(_media)
 
 
-class AdminTinyMCE(admin_widgets.AdminTextareaWidget, TinyMCE):
+class AdminTinyMCE(TinyMCE, admin_widgets.AdminTextareaWidget):
     pass
 
 


### PR DESCRIPTION
widgets.AdminTinyMCE was failing to instantiate when mce_attrs was provided, complaining that **init** got an unexpected kwarg, "mce_attrs".  This was because AdminTinyMCE first inherited from AdminTextareaWidget, and then TinyMCE.  I reversed this order and it now works as expected.

I didn't see any way to run automated tests so I'm not sure there's no regression, but I exercised it pretty thoroughly and it seems to be working.
