### PR TITLE
Handle non-admin jQuery

### DIFF
--- a/tinymce/static/django_tinymce/init_tinymce.js
+++ b/tinymce/static/django_tinymce/init_tinymce.js
@@ -35,4 +35,4 @@
       }, 0);
     }, true);
   });
-}(django.jQuery));
+}( function (django) { return django && django.jQuery || jQuery }()));


### PR DESCRIPTION
Safely handle cases where jQuery comes form admin (and is called django.jQuery) and where it is loaded outside of admin (and is called jQuery).