### PR TITLE
Change MEDIA_ROOT to MEDIA_URL for TINYMCE_JS_URL

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -110,7 +110,7 @@ file.
 ``TINYMCE_JS_URL`` (default: ``settings.MEDIA_URL + 'js/tiny_mce/tiny_mce.js'``)
     The URL of the TinyMCE javascript file::
 
-        TINYMCE_JS_URL = os.path.join(MEDIA_ROOT, "path/to/tiny_mce/tiny_mce.js")
+        TINYMCE_JS_URL = os.path.join(MEDIA_URL, "path/to/tiny_mce/tiny_mce.js")
 
 ``TINYMCE_JS_ROOT`` (default: ``settings.MEDIA_ROOT + 'js/tiny_mce'``)
   The filesystem location of the TinyMCE files. It is used by the compressor


### PR DESCRIPTION
Just a documentation fix.