### PR TITLE
removed usage of simplejson. Deprecated in Django.

### DIFF
--- a/tinymce/views.py
+++ b/tinymce/views.py
@@ -2,11 +2,11 @@
 # Licensed under the terms of the MIT License (see LICENSE.txt)
 
 import logging
+import json
 from django.core import urlresolvers
 from django.http import HttpResponse
 from django.shortcuts import render_to_response
 from django.template import RequestContext, loader
-from django.utils import simplejson
 from django.utils.translation import ugettext as _
 from tinymce.compressor import gzip_compressor
 from tinymce.widgets import get_language_config
@@ -43,7 +43,7 @@ def spell_check(request):
         import enchant
 
         raw = request.raw_post_data
-        input = simplejson.loads(raw)
+        input = json.loads(raw)
         id = input['id']
         method = input['method']
         params = input['params']
@@ -69,7 +69,7 @@ def spell_check(request):
     except Exception:
         logging.exception("Error running spellchecker")
         return HttpResponse(_("Error running spellchecker"))
-    return HttpResponse(simplejson.dumps(output),
+    return HttpResponse(json.dumps(output),
             content_type='application/json')
 
 try:
@@ -126,7 +126,7 @@ def render_to_image_list(image_list):
     return render_to_js_vardef('tinyMCEImageList', image_list)
 
 def render_to_js_vardef(var_name, var_value):
-    output = "var %s = %s" % (var_name, simplejson.dumps(var_value))
+    output = "var %s = %s" % (var_name, json.dumps(var_value))
     return HttpResponse(output, content_type='application/x-javascript')
 
 def filebrowser(request):


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.7/releases/1.5/#system-version-of-simplejson-no-longer-used