### PR TITLE
Fixes TypeError in DJANGO 1.8

### DIFF
--- a/tinymce/settings.py
+++ b/tinymce/settings.py
@@ -11,7 +11,12 @@ USE_COMPRESSOR = getattr(settings, 'TINYMCE_COMPRESSOR', False)
 USE_FILEBROWSER = getattr(settings, 'TINYMCE_FILEBROWSER',
         'filebrowser' in settings.INSTALLED_APPS)
 
+
+
 if 'staticfiles' in settings.INSTALLED_APPS or 'django.contrib.staticfiles' in settings.INSTALLED_APPS:
+    if not settings.STATIC_ROOT: #Fix for Django 1.8 which sets STATIC_ROOT as NONE.
+        settings.STATIC_ROOT = ''
+
     JS_URL = getattr(settings, 'TINYMCE_JS_URL',os.path.join(settings.STATIC_URL, 'tiny_mce/tiny_mce.js'))
     JS_ROOT = getattr(settings, 'TINYMCE_JS_ROOT',os.path.join(settings.STATIC_ROOT, 'tiny_mce'))
 else:


### PR DESCRIPTION
Fixes Error in DJANGO 1.8. 
settings.STATIC_ROOT defaults to None in that version resulting in an error when attempting to make JS_ROOT:

`
File "C:\\env\lib\site-packages\tinymce\settings.py", line 21, in <module>
    JS_ROOT = getattr(settings, 'TINYMCE_JS_ROOT',os.path.join(settings.STATIC_ROOT, 'tiny_mce'))
  File "C:\\env\lib\ntpath.py", line 64, in join
    result_drive, result_path = splitdrive(path)
  File "C:\\env\lib\ntpath.py", line 114, in splitdrive
    if len(p) > 1:
TypeError: object of type 'NoneType' has no len()
`

This fixes issue #115