### PR TITLE
Fix for crashes when using tinymce in STATICFILES_DIRS in development mode.

### DIFF
--- a/tinymce/settings.py
+++ b/tinymce/settings.py
@@ -1,5 +1,6 @@
 import os
 from django.conf import settings
+from django.contrib.staticfiles import finders
 
 DEFAULT_CONFIG = getattr(settings, 'TINYMCE_DEFAULT_CONFIG',
         {'theme': "simple", 'relative_urls': False})
@@ -13,7 +14,7 @@ USE_FILEBROWSER = getattr(settings, 'TINYMCE_FILEBROWSER',
 
 if 'staticfiles' in settings.INSTALLED_APPS or 'django.contrib.staticfiles' in settings.INSTALLED_APPS:
     JS_URL = getattr(settings, 'TINYMCE_JS_URL',os.path.join(settings.STATIC_URL, 'tiny_mce/tiny_mce.js'))
-    JS_ROOT = getattr(settings, 'TINYMCE_JS_ROOT',os.path.join(settings.STATIC_ROOT, 'tiny_mce'))
+    JS_ROOT = getattr(settings, 'TINYMCE_JS_ROOT', finders.find('tiny_mce', all=False))
 else:
     JS_URL = getattr(settings, 'TINYMCE_JS_URL','%sjs/tiny_mce/tiny_mce.js' % settings.MEDIA_URL)
     JS_ROOT = getattr(settings, 'TINYMCE_JS_ROOT', os.path.join(settings.MEDIA_ROOT, 'js/tiny_mce'))


### PR DESCRIPTION
Here I've added some quick and dirty fix when using STATICFILES_DIRS instead of STATIC_ROOT.