### PR TITLE
Fixed django.jQuery vs. jQuery passing issue in init_tinymce.js

### DIFF
--- a/tinymce/static/django_tinymce/init_tinymce.js
+++ b/tinymce/static/django_tinymce/init_tinymce.js
@@ -35,4 +35,4 @@
       }, 0);
     }, true);
   });
-}(django && django.jQuery || jQuery));
+}((typeof django === 'undefined' || typeof django.jQuery === 'undefined') && jQuery || django && django.jQuery));


### PR DESCRIPTION
Fixes #124. Changed the order of the parameter passing and added checks against "undefined" for django and django.jQuery to preserve the preference for django.jQuery if it is defined.