### PR TITLE
[tinymce4] Django 1.9 compatibility

### DIFF
--- a/tinymce/urls.py
+++ b/tinymce/urls.py
@@ -1,17 +1,18 @@
 # Copyright (c) 2008 Joost Cassee
 # Licensed under the terms of the MIT License (see LICENSE.txt)
+from tinymce.views import textareas_js, spell_check, flatpages_link_list, compressor, filebrowser, preview
 
 try:
-    from django.conf.urls import url, patterns
+    from django.conf.urls import url
 except:
-    from django.conf.urls.defaults import *
+    from django.conf.urls.defaults import url
 
-urlpatterns = patterns('tinymce.views',
-    url(r'^js/textareas/(?P<name>.+)/$', 'textareas_js', name='tinymce-js'),
-    url(r'^js/textareas/(?P<name>.+)/(?P<lang>.*)$', 'textareas_js', name='tinymce-js-lang'),
-    url(r'^spellchecker/$', 'spell_check'),
-    url(r'^flatpages_link_list/$', 'flatpages_link_list'),
-    url(r'^compressor/$', 'compressor', name='tinymce-compressor'),
-    url(r'^filebrowser/$', 'filebrowser', name='tinymce-filebrowser'),
-    url(r'^preview/(?P<name>.+)/$', 'preview', name='tinymce-preview'),
-)
+urlpatterns = [
+    url(r'^js/textareas/(?P<name>.+)/$', textareas_js, name='tinymce-js'),
+    url(r'^js/textareas/(?P<name>.+)/(?P<lang>.*)$', textareas_js, name='tinymce-js-lang'),
+    url(r'^spellchecker/$', spell_check),
+    url(r'^flatpages_link_list/$', flatpages_link_list),
+    url(r'^compressor/$', compressor, name='tinymce-compressor'),
+    url(r'^filebrowser/$', filebrowser, name='tinymce-filebrowser'),
+    url(r'^preview/(?P<name>.+)/$', preview, name='tinymce-preview'),
+]

--- a/tinymce/views.py
+++ b/tinymce/views.py
@@ -6,14 +6,20 @@ from django.core import urlresolvers
 from django.http import HttpResponse
 from django.shortcuts import render_to_response
 from django.template import RequestContext, loader
-import simplejson
 from django.utils.translation import ugettext as _
 from tinymce.compressor import gzip_compressor
 from tinymce.widgets import get_language_config
+
 try:
     from django.views.decorators.csrf import csrf_exempt
 except ImportError:
     pass
+
+try:
+    import json
+except ImportError:
+    import simplejson as json
+
 
 def textareas_js(request, name, lang=None):
     """
@@ -43,7 +49,7 @@ def spell_check(request):
         import enchant
 
         raw = request.raw_post_data
-        input = simplejson.loads(raw)
+        input = json.loads(raw)
         id = input['id']
         method = input['method']
         params = input['params']
@@ -69,7 +75,7 @@ def spell_check(request):
     except Exception:
         logging.exception("Error running spellchecker")
         return HttpResponse(_("Error running spellchecker"))
-    return HttpResponse(simplejson.dumps(output),
+    return HttpResponse(json.dumps(output),
             content_type='application/json')
 
 try:
@@ -126,7 +132,7 @@ def render_to_image_list(image_list):
     return render_to_js_vardef('tinyMCEImageList', image_list)
 
 def render_to_js_vardef(var_name, var_value):
-    output = "var %s = %s" % (var_name, simplejson.dumps(var_value))
+    output = "var %s = %s" % (var_name, json.dumps(var_value))
     return HttpResponse(output, content_type='application/x-javascript')
 
 def filebrowser(request):

--- a/tinymce/widgets.py
+++ b/tinymce/widgets.py
@@ -105,7 +105,7 @@ class TinyMCE(forms.Textarea):
     media = property(_media)
 
 
-class AdminTinyMCE(admin_widgets.AdminTextareaWidget, TinyMCE):
+class AdminTinyMCE(TinyMCE, admin_widgets.AdminTextareaWidget):
     pass
 
 

--- a/tinymce/widgets.py
+++ b/tinymce/widgets.py
@@ -12,6 +12,12 @@ from django.conf import settings
 from django.contrib.admin import widgets as admin_widgets
 from django.core.urlresolvers import reverse
 from django.forms.widgets import flatatt
+
+try:
+    from django.utils.datastructures import SortedDict
+except ImportError:
+    from collections import OrderedDict as SortedDict
+
 try:
     from django.utils.encoding import smart_text as smart_unicode
 except ImportError:
@@ -20,7 +26,6 @@ except ImportError:
     except ImportError:
         from django.forms.util import smart_unicode
 from django.utils.html import escape
-from django.utils.datastructures import SortedDict
 from django.utils.safestring import mark_safe
 from django.utils.translation import get_language, ugettext as _
 import tinymce.settings


### PR DESCRIPTION
`django.utils.datastructures.SortedDict` was deprecated in Django 1.7 and finally removed in 1.9.

The semantics are the same as the stdlib's `collections.OrderedDict`, so fall back to that.