### PR TITLE
Updated urls.py to use modern conventions:

### DIFF
--- a/testtinymce/urls.py
+++ b/testtinymce/urls.py
@@ -1,17 +1,17 @@
 from django.conf import settings
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.contrib import admin
-try:
-    from django.conf.urls import patterns, include, url
-except ImportError:
-    from django.conf.urls.defaults import patterns, include, url
+from django.conf.urls import include, url
+
+import tinymce.urls
 
 admin.autodiscover()
 
-urlpatterns = patterns('',
-    url(r'^tinymce/', include('tinymce.urls')),
+urlpatterns = [
+    url(r'^tinymce/', include(tinymce.urls)),
     url(r'^admin/', include(admin.site.urls)),
     #url(r'^%s(?P<path>.*)$' % settings.MEDIA_URL[1:], 
     #    'django.views.static.serve', {"document_root": settings.MEDIA_ROOT}),
-)
+]
+
 urlpatterns += staticfiles_urlpatterns()

--- a/tinymce/urls.py
+++ b/tinymce/urls.py
@@ -1,17 +1,16 @@
 # Copyright (c) 2008 Joost Cassee
 # Licensed under the terms of the MIT License (see LICENSE.txt)
 
-try:
-    from django.conf.urls import url, patterns
-except:
-    from django.conf.urls.defaults import url, patterns
+from django.conf.urls import url
 
-urlpatterns = patterns('tinymce.views',
-    url(r'^js/textareas/(?P<name>.+)/$', 'textareas_js', name='tinymce-js'),
-    url(r'^js/textareas/(?P<name>.+)/(?P<lang>.*)$', 'textareas_js', name='tinymce-js-lang'),
-    url(r'^spellchecker/$', 'spell_check'),
-    url(r'^flatpages_link_list/$', 'flatpages_link_list'),
-    url(r'^compressor/$', 'compressor', name='tinymce-compressor'),
-    url(r'^filebrowser/$', 'filebrowser', name='tinymce-filebrowser'),
-    url(r'^preview/(?P<name>.+)/$', 'preview', name='tinymce-preview'),
-)
+from . import views
+
+urlpatterns = [
+    url(r'^js/textareas/(?P<name>.+)/$', views.textareas_js, name='tinymce-js'),
+    url(r'^js/textareas/(?P<name>.+)/(?P<lang>.*)$', views.textareas_js, name='tinymce-js-lang'),
+    url(r'^spellchecker/$', views.spell_check),
+    url(r'^flatpages_link_list/$', views.flatpages_link_list),
+    url(r'^compressor/$', views.compressor, name='tinymce-compressor'),
+    url(r'^filebrowser/$', views.filebrowser, name='tinymce-filebrowser'),
+    url(r'^preview/(?P<name>.+)/$', views.preview, name='tinymce-preview'),
+]


### PR DESCRIPTION
- don't use string imports

- don't use partterns()