### PR TITLE
Fixed Django 1.9 compatibility: Pass views as callables, not as strings

### DIFF
--- a/tinymce/urls.py
+++ b/tinymce/urls.py
@@ -1,17 +1,18 @@
 # Copyright (c) 2008 Joost Cassee
 # Licensed under the terms of the MIT License (see LICENSE.txt)
+from tinymce.views import textareas_js, spell_check, flatpages_link_list, compressor, filebrowser, preview
 
 try:
-    from django.conf.urls import url, patterns
+    from django.conf.urls import url
 except:
-    from django.conf.urls.defaults import url, patterns
+    from django.conf.urls.defaults import url
 
-urlpatterns = patterns('tinymce.views',
-    url(r'^js/textareas/(?P<name>.+)/$', 'textareas_js', name='tinymce-js'),
-    url(r'^js/textareas/(?P<name>.+)/(?P<lang>.*)$', 'textareas_js', name='tinymce-js-lang'),
-    url(r'^spellchecker/$', 'spell_check'),
-    url(r'^flatpages_link_list/$', 'flatpages_link_list'),
-    url(r'^compressor/$', 'compressor', name='tinymce-compressor'),
-    url(r'^filebrowser/$', 'filebrowser', name='tinymce-filebrowser'),
-    url(r'^preview/(?P<name>.+)/$', 'preview', name='tinymce-preview'),
-)
+urlpatterns = [
+    url(r'^js/textareas/(?P<name>.+)/$', textareas_js, name='tinymce-js'),
+    url(r'^js/textareas/(?P<name>.+)/(?P<lang>.*)$', textareas_js, name='tinymce-js-lang'),
+    url(r'^spellchecker/$', spell_check),
+    url(r'^flatpages_link_list/$', flatpages_link_list),
+    url(r'^compressor/$', compressor, name='tinymce-compressor'),
+    url(r'^filebrowser/$', filebrowser, name='tinymce-filebrowser'),
+    url(r'^preview/(?P<name>.+)/$', preview, name='tinymce-preview'),
+]

--- a/tinymce/urls.py
+++ b/tinymce/urls.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2008 Joost Cassee
 # Licensed under the terms of the MIT License (see LICENSE.txt)
-from tinymce.views import textareas_js, spell_check, flatpages_link_list, compressor, filebrowser, preview
+from tinymce import views
 
 try:
     from django.conf.urls import url
@@ -8,11 +8,11 @@ except:
     from django.conf.urls.defaults import url
 
 urlpatterns = [
-    url(r'^js/textareas/(?P<name>.+)/$', textareas_js, name='tinymce-js'),
-    url(r'^js/textareas/(?P<name>.+)/(?P<lang>.*)$', textareas_js, name='tinymce-js-lang'),
-    url(r'^spellchecker/$', spell_check),
-    url(r'^flatpages_link_list/$', flatpages_link_list),
-    url(r'^compressor/$', compressor, name='tinymce-compressor'),
-    url(r'^filebrowser/$', filebrowser, name='tinymce-filebrowser'),
-    url(r'^preview/(?P<name>.+)/$', preview, name='tinymce-preview'),
+    url(r'^js/textareas/(?P<name>.+)/$', views.textareas_js, name='tinymce-js'),
+    url(r'^js/textareas/(?P<name>.+)/(?P<lang>.*)$', views.textareas_js, name='tinymce-js-lang'),
+    url(r'^spellchecker/$', views.spell_check),
+    url(r'^flatpages_link_list/$', views.flatpages_link_list),
+    url(r'^compressor/$', views.compressor, name='tinymce-compressor'),
+    url(r'^filebrowser/$', views.filebrowser, name='tinymce-filebrowser'),
+    url(r'^preview/(?P<name>.+)/$', views.preview, name='tinymce-preview'),
 ]


### PR DESCRIPTION
Conflicts:
	tinymce/urls.py
Fixes #145 