### PR TITLE
Add support for passing JavaScript function names via Python configuration

### DIFF
--- a/tinymce/static/django_tinymce/init_tinymce.js
+++ b/tinymce/static/django_tinymce/init_tinymce.js
@@ -6,6 +6,19 @@ var django = django || {
   function initTinyMCE($e) {
     if ($e.parents('.empty-form').length == 0) {  // Don't do empty inlines
       var mce_conf = $.parseJSON($e.attr('data-mce-conf'));
+      // There is no way to pass a JavaScript function as an option, because
+      // all options are serialized as JSON. For any TinyMCE options that expect
+      // functions, assume that we were given a function name, and resolve that
+      // to a function reference using the `window` global.
+      var fns = ['color_picker_callback', 'file_browser_callback', 'file_picker_callback',
+            'images_dataimg_filter', 'images_upload_handler'];
+      for (var i=0;i<fns.length;i++) {
+        if (typeof mce_conf[fns[i]] !== undefined) {
+          var fn = mce_conf[fns[i]];
+          mce_conf[fns[i]] = window[fn];  // resolve function name to reference
+        }
+      }
+
       var id = $e.attr('id');
       if ('elements' in mce_conf && mce_conf['mode'] == 'exact') {
         mce_conf['elements'] = id;


### PR DESCRIPTION
As far as I can tell, there is currently no way to specify a JavaScript function as the value of one of the TinyMCE options that expects one: file_browser_callback, file_picker_callback, etc. This is because all of the options are serialized as JSON, included in the data-mce-conf attribute of the `<textarea>` rendered by the widget. And JSON doesn't support references to functions.

This pull request allows a user to specify a JavaScript function's name as the value associated with one of these options. When the configuration settings are unpacked, and prior to calling tinymce.init(), the function name is resolved to a function reference using the global `window` object.

So, for example, you can now do something like this in a ModelAdmin / StackedInline:

``` Python
    def formfield_for_dbfield(self, db_field, **kwargs):
        if db_field.name == 'body':
            kwargs['widget'] = AdminTinyMCE(
                mce_attrs = {
                    'width': 375,
                    'file_browser_callback': 'my_callback',
                })        
        return super(PerspectiveInline, self).formfield_for_dbfield(db_field,
                                                                    **kwargs)
```

This will set up a function `my_callback` (assumed to be defined in the JS assets associated with the page) as the file_browser_callback.

You could do something similar with default config in your settings.py:

``` Python
TINYMCE_DEFAULT_CONFIG = {
  'color_picker_callback': 'myColorPicker'
}
```
