### PR TITLE
Remove hardcoded protocol from embeds

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -32,3 +32,4 @@ Contributors
 * Venelin Stoykov <vkstoykov@gmail.com>
 * Zuzel Vera <zuzel.vp@gmail.com>
 * Ivan Chernov <chernoffivan@gmail.com>
+* Andrew Meakovski <meako689@gmail.com>

--- a/tinymce/static/tiny_mce/plugins/media/js/media.js
+++ b/tinymce/static/tiny_mce/plugins/media/js/media.js
@@ -310,7 +310,7 @@
 						data.height = 350;
 						data.params.frameborder = '0';
 						data.type = 'iframe';
-						src = 'http://www.youtube.com/embed/' + src.match(/youtu.be\/([a-z1-9.-_]+)/)[1];
+						src = '//www.youtube.com/embed/' + src.match(/youtu.be\/([a-z1-9.-_]+)/)[1];
 						setVal('src', src);
 						setVal('media_type', data.type);
 					}
@@ -321,7 +321,7 @@
 						data.height = 350;
 						data.params.frameborder = '0';
 						data.type = 'iframe';
-						src = 'http://www.youtube.com/embed/' + src.match(/v=([^&]+)/)[1];
+						src = '//www.youtube.com/embed/' + src.match(/v=([^&]+)/)[1];
 						setVal('src', src);
 						setVal('media_type', data.type);
 					}
@@ -332,7 +332,7 @@
 					data.width = 425;
 					data.height = 326;
 					data.type = 'flash';
-					src = 'http://video.google.com/googleplayer.swf?docId=' + src.match(/docid=([^&]+)/)[1] + '&hl=en';
+					src = '//video.google.com/googleplayer.swf?docId=' + src.match(/docid=([^&]+)/)[1] + '&hl=en';
 					setVal('src', src);
 					setVal('media_type', data.type);
 				}
@@ -343,7 +343,7 @@
 					data.height = 350;
 					data.params.frameborder = '0';
 					data.type = 'iframe';
-					src = 'http://player.vimeo.com/video/' + src.match(/vimeo.com\/([0-9]+)/)[1];
+					src = '//player.vimeo.com/video/' + src.match(/vimeo.com\/([0-9]+)/)[1];
 					setVal('src', src);
 					setVal('media_type', data.type);
 				}
@@ -354,7 +354,7 @@
 					data.height = 350;
 					data.params.frameborder = '0';
 					data.type = 'iframe';
-					src = 'http://www.stream.cz/object/' + src.match(/stream.cz\/[^/]+\/([0-9]+)/)[1];
+					src = '//www.stream.cz/object/' + src.match(/stream.cz\/[^/]+\/([0-9]+)/)[1];
 					setVal('src', src);
 					setVal('media_type', data.type);
 				}
@@ -365,7 +365,7 @@
 					data.height = 350;
 					data.params.frameborder = '0';
 					data.type = 'iframe';
-					src = 'http://maps.google.com/maps/ms?msid=' + src.match(/msid=(.+)/)[1] + "&output=embed";
+					src = '//maps.google.com/maps/ms?msid=' + src.match(/msid=(.+)/)[1] + "&output=embed";
 					setVal('src', src);
 					setVal('media_type', data.type);
 				}


### PR DESCRIPTION
Embedding videos doesn't work for websites that use https in modern browsers due to mixed-content policy (codes are generated with http).

I've removed hardcoded protocol string from code that is generated for embeds. 