### PR TITLE
FIX: Refused to execute script

### DIFF
--- a/tinymce/views.py
+++ b/tinymce/views.py
@@ -105,4 +105,9 @@ def filebrowser(request):
     except:
         fb_url = request.build_absolute_uri(urlresolvers.reverse('filebrowser:fb_browse'))
 
-    return render(request, 'tinymce/filebrowser.js', {'fb_url': fb_url})
+    return render(
+        request,
+        'tinymce/filebrowser.js',
+        {'fb_url': fb_url},
+        content_type='application/javascript'
+    )


### PR DESCRIPTION
Chrome browser rejects the file 'http://domain/tinymce/filebrowser/'. This message get in the console browser:

```
Refused to execute script from 'http://domain/tinymce/filebrowser/'
because its MIME type ('text/html') is not executable, and strict MIME
type checking is enabled.
```

The patch fixes this of course.