### PR TITLE
Fixed paste_preprocess & paste_postprocess if set in TINYMCE_DEFAULT_CONFIG

### DIFF
--- a/tinymce/widgets.py
+++ b/tinymce/widgets.py
@@ -71,7 +71,7 @@ class TinyMCE(forms.Textarea):
         mce_json = json.dumps(mce_config)
         for k in js_functions:
             index = mce_json.rfind('}')
-            mce_json = mce_json[:index] + ', ' + k + ':' + js_functions[k].strip() + mce_json[index:]
+            mce_json = mce_json[:index] + ', \"' + k + '\":\"' + js_functions[k].strip() + '\"' + mce_json[index:]
         return mce_json
 
     def render(self, name, value, attrs=None):


### PR DESCRIPTION
Fixed a JSON parsing error because of the missing quoting if paste_preprocess or paste_postprocess was set in TINYMCE_DEFAULT_CONFIG

https://github.com/aljosa/django-tinymce/issues/166
