### PR TITLE
Add compatibility for Django 1.10.5

### DIFF
--- a/testtinymce/settings.py
+++ b/testtinymce/settings.py
@@ -41,6 +41,11 @@ TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth'
+            ]
+        },
     },
 ]
 


### PR DESCRIPTION
Django 1.10.5 throws an error: "?: (admin.E402) 'django.contrib.auth.context_processors.auth' must be in TEMPLATES in order to use the admin application" when you try to export testtinymce.settings, and make a migration.
Tested on Django 1.8.14 & Django 1.10.5. Works perfectly.