### PR TITLE
Added the "TINYMCE_EXTRA_MEDIA" setting

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -141,6 +141,9 @@ file.
   reduces the number of requests. The overall initialization time for TinyMCE
   will be reduced dramatically if you use this option.
 
+``TINYMCE_EXTRA_MEDIA`` (default: ``None``)
+  Extra media to include on the page with the :ref:`widget <widget>`.
+
 ``TINYMCE_FILEBROWSER`` (default: ``True`` if ``'filebrowser'`` is in ``INSTALLED_APPS``, else ``False``)
   Whether to use the django-filebrowser_ as a custom filebrowser for media inclusion.
   See the `official TinyMCE documentation on custom filebrowsers`_.
@@ -156,6 +159,16 @@ Example::
   }
   TINYMCE_SPELLCHECKER = True
   TINYMCE_COMPRESSOR = True
+  TINYMCE_EXTRA_MEDIA = {
+      'css': {
+          'all': [
+              ...
+          ],
+      },
+      'js': [
+          ...
+      ],
+  }
 
 .. _`the TinyMCE manual`: http://www.tinymce.com/wiki.php/configuration
 .. _`official TinyMCE documentation on custom filebrowsers`: http://www.tinymce.com/wiki.php/TinyMCE3x:How-to_implement_a_custom_file_browser

--- a/tinymce/settings.py
+++ b/tinymce/settings.py
@@ -9,6 +9,8 @@ USE_SPELLCHECKER = getattr(settings, 'TINYMCE_SPELLCHECKER', False)
 
 USE_COMPRESSOR = getattr(settings, 'TINYMCE_COMPRESSOR', False)
 
+USE_EXTRA_MEDIA = getattr(settings, 'TINYMCE_EXTRA_MEDIA', None)
+
 USE_FILEBROWSER = getattr(settings, 'TINYMCE_FILEBROWSER',
                           'filebrowser' in settings.INSTALLED_APPS)
 

--- a/tinymce/widgets.py
+++ b/tinymce/widgets.py
@@ -101,15 +101,22 @@ class TinyMCE(forms.Textarea):
         return mark_safe('\n'.join(html))
 
     def _media(self):
+        css = None
         if tinymce.settings.USE_COMPRESSOR:
             js = [reverse('tinymce-compressor')]
         else:
             js = [tinymce.settings.JS_URL]
         if tinymce.settings.USE_FILEBROWSER:
             js.append(reverse('tinymce-filebrowser'))
+        if tinymce.settings.USE_EXTRA_MEDIA:
+            if 'js' in tinymce.settings.USE_EXTRA_MEDIA:
+                js += tinymce.settings.USE_EXTRA_MEDIA['js']
+
+            if 'css' in tinymce.settings.USE_EXTRA_MEDIA:
+                css = tinymce.settings.USE_EXTRA_MEDIA['css']
         js.append('django_tinymce/jquery-1.9.1.min.js')
         js.append('django_tinymce/init_tinymce.js')
-        return forms.Media(js=js)
+        return forms.Media(css=css, js=js)
     media = property(_media)
 
 


### PR DESCRIPTION
This is possibly enough to close #28. Although it doesn't touch the `TINYMCE_FILEBROWSER` setting, it does allow for other file browsers. For example:

```python
TINYMCE_DEFAULT_CONFIG = {
    ...
    'file_browser_callback': "CustomFileBrowser",
}

TINYMCE_EXTRA_MEDIA = {
    'js': [
        '/path/to/javascript/file/that/defines/CustomFileBrowser',
    ],
}
```

This would simplify things for [this project](https://github.com/aisayko/Django-tinymce-filebrowser) too.