### PR TITLE
Add renderer parameter to widgets.TinyMCE.render()

### DIFF
--- a/tinymce/widgets.py
+++ b/tinymce/widgets.py
@@ -69,7 +69,7 @@ class TinyMCE(forms.Textarea):
             mce_config['elements'] = attrs['id']
         return mce_config
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if value is None:
             value = ''
         value = force_text(value)


### PR DESCRIPTION
This parameter appeared in Django 1.11.4 as part of the template-based widget rendering feature and will be a mandatory parameter in Django 2.1