### PR TITLE
Fix dropped attributes overriding widgets with TinyMCE widget

### DIFF
--- a/tinymce/widgets.py
+++ b/tinymce/widgets.py
@@ -69,11 +69,17 @@ class TinyMCE(forms.Textarea):
             mce_config['elements'] = attrs['id']
         return mce_config
 
+    def build_attrs(self, base_attrs, extra_attrs=None, **kwargs):
+        attributes = dict(base_attrs, **kwargs)
+        if extra_attrs:
+            attributes.update(extra_attrs)
+        return attributes
+
     def render(self, name, value, attrs=None):
         if value is None:
             value = ''
         value = force_text(value)
-        final_attrs = self.build_attrs(attrs)
+        final_attrs = self.build_attrs(self.attrs, attrs)
         final_attrs['name'] = name
         if final_attrs.get('class', None) is None:
             final_attrs['class'] = 'tinymce'


### PR DESCRIPTION
I'm using django-tinymce in tandem with django-modeltranslations and have been frustrated that translated fields would not be grouped into tabs. Turns out, that css class attributes that are added by modeltranslations are dropped on render of the TinyMCE widget. The reason is the usage of `Widget.build_attrs` in `TinyMCE.render`. Only extra attributes are build and used to render the widget.

Judging by the CI runs, the signature of `build_attrs` has changed with Django 1.11. How could this be handled?