### PR TITLE
docs: Fix simple typo, positon -> position

### DIFF
--- a/tinymce/media/tiny_mce/plugins/table/editor_plugin_src.js
+++ b/tinymce/media/tiny_mce/plugins/table/editor_plugin_src.js
@@ -695,7 +695,7 @@
 				endX = Math.max(startPos.x, endPos.x);
 				endY = Math.max(startPos.y, endPos.y);
 
-				// Expand end positon to include spans
+				// Expand end position to include spans
 				maxX = endX;
 				maxY = endY;
 

--- a/tinymce/media/tiny_mce/tiny_mce_src.js
+++ b/tinymce/media/tiny_mce/tiny_mce_src.js
@@ -15742,7 +15742,7 @@ tinymce.create('tinymce.ui.Toolbar:tinymce.ui.Container', {
 		editor.onKeyDown.add(function(editor, e) {
 			var keyCode = e.keyCode;
 
-			// Is caracter positon keys left,right,up,down,home,end,pgdown,pgup,enter
+			// Is caracter position keys left,right,up,down,home,end,pgdown,pgup,enter
 			if ((keyCode >= 33 && keyCode <= 36) || (keyCode >= 37 && keyCode <= 40) || keyCode == 45) {
 				if (self.typing) {
 					addNonTypingUndoLevel();

--- a/tinymce/static/tiny_mce/plugins/table/editor_plugin_src.js
+++ b/tinymce/static/tiny_mce/plugins/table/editor_plugin_src.js
@@ -695,7 +695,7 @@
 				endX = Math.max(startPos.x, endPos.x);
 				endY = Math.max(startPos.y, endPos.y);
 
-				// Expand end positon to include spans
+				// Expand end position to include spans
 				maxX = endX;
 				maxY = endY;
 

--- a/tinymce/static/tiny_mce/tiny_mce_src.js
+++ b/tinymce/static/tiny_mce/tiny_mce_src.js
@@ -15742,7 +15742,7 @@ tinymce.create('tinymce.ui.Toolbar:tinymce.ui.Container', {
 		editor.onKeyDown.add(function(editor, e) {
 			var keyCode = e.keyCode;
 
-			// Is caracter positon keys left,right,up,down,home,end,pgdown,pgup,enter
+			// Is caracter position keys left,right,up,down,home,end,pgdown,pgup,enter
 			if ((keyCode >= 33 && keyCode <= 36) || (keyCode >= 37 && keyCode <= 40) || keyCode == 45) {
 				if (self.typing) {
 					addNonTypingUndoLevel();


### PR DESCRIPTION
There is a small typo in tinymce/media/tiny_mce/plugins/table/editor_plugin_src.js, tinymce/media/tiny_mce/tiny_mce_src.js, tinymce/static/tiny_mce/plugins/table/editor_plugin_src.js, tinymce/static/tiny_mce/tiny_mce_src.js.

Should read `position` rather than `positon`.

