### PR TITLE
Upgrade test matrix to include Django 2.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
       env: TOX_ENV=py35-django20
     - python: 3.5
       env: TOX_ENV=py35-django21
+    - python: 3.5
+      env: TOX_ENV=py35-django22
 
     - python: 3.6
       env: TOX_ENV=flake8
@@ -16,6 +18,8 @@ matrix:
       env: TOX_ENV=py36-django20
     - python: 3.6
       env: TOX_ENV=py36-django21
+    - python: 3.6
+      env: TOX_ENV=py36-django22
 
     - python: 3.7
       dist: xenial
@@ -26,6 +30,9 @@ matrix:
     - python: 3.7
       dist: xenial
       env: TOX_ENV=py37-django21
+    - python: 3.7
+      dist: xenial
+      env: TOX_ENV=py37-django22
 addons:
   apt:
     packages:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ This document describes changes between each past release.
 2.9.0 (unreleased)
 ==================
 
-- Upgrade test matrix to Python 3.7 and Django 2.1
+- Upgrade test matrix to Python 3.7 and Django 2.1, 2.2
 
 
 2.8.0 (2019-01-15)

--- a/testtinymce/settings.py
+++ b/testtinymce/settings.py
@@ -45,6 +45,7 @@ TEMPLATES = [
         'OPTIONS': {
             'context_processors': [
                 "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
             ]
         },
     },

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
     py27-django{111},
-    py35-django{20,21},
-    py36-django{20,21},
-    py37-django{20,21},
+    py35-django{20,21,22},
+    py36-django{20,21,22},
+    py37-django{20,21,22},
     flake8
 
 [testenv]
@@ -11,6 +11,7 @@ deps =
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
+    django22: Django>=2.2,<3.0
     coverage
     mock
     pyenchant


### PR DESCRIPTION
Enable Django 2.2 test environment.
Related to #251 issue.